### PR TITLE
Opendingux buildroot fixes

### DIFF
--- a/package/gmenu2x/0001-CMakeLists.txt.patch
+++ b/package/gmenu2x/0001-CMakeLists.txt.patch
@@ -1,0 +1,47 @@
+diff -u gmenu2x/CMakeLists.txt gmenu2x/CMakeLists.txt
+--- gmenu2x/CMakeLists.txt	2019-10-03 01:56:10.498139706 +0200
++++ gmenu2x/CMakeLists.txt	2019-10-03 01:58:58.395128182 +0200
+@@ -6,17 +6,17 @@
+ 
+ option(CPUFREQ "Enable CPU frequency control" OFF)
+ if (CPUFREQ)
+-	add_compile_definitions(ENABLE_CPUFREQ)
++	add_definitions(-DENABLE_CPUFREQ)
+ endif(CPUFREQ)
+ 
+ option(CLOCK "Display current time at the bottom of the screen" ON)
+ if (CLOCK)
+-	add_compile_definitions(ENABLE_CLOCK)
++	add_definitions(-DENABLE_CLOCK)
+ endif (CLOCK)
+ 
+ option(BIND_CONSOLE "Support for binding/unbinding terminal" OFF)
+ if (BIND_CONSOLE)
+-	add_compile_definitions(BIND_CONSOLE)
++	add_definitions(-DBIND_CONSOLE)
+ endif (BIND_CONSOLE)
+ 
+ set(CARD_ROOT "/media" CACHE STRING "Top-level filesystem directory")
+@@ -52,11 +52,11 @@
+ if(LIBOPK_FOUND)
+ 	set(LIBOPK_LIBRARIES ${LIBOPK_LIBRARY})
+ 	set(LIBOPK_INCLUDE_DIRS ${LIBOPK_INCLUDE_DIR})
+-	add_compile_definitions(HAVE_LIBOPK)
++	add_definitions(-DHAVE_LIBOPK)
+ 
+ 	option(INOTIFY "Monitor OPK folder with inotify" ON)
+ 	if (INOTIFY)
+-		add_compile_definitions(ENABLE_INOTIFY)
++		add_definitions(-DENABLE_INOTIFY)
+ 	endif (INOTIFY)
+ endif(LIBOPK_FOUND)
+ 
+@@ -68,7 +68,7 @@
+ if (LIBXDGMIME_FOUND)
+ 	set(LIBXDGMIME_LIBRARIES ${LIBXDGMIME_LIBRARY})
+ 	set(LIBXDGMIME_INCLUDE_DIRS ${LIBXDGMIME_INCLUDE_DIR})
+-	add_compile_definitions(HAVE_LIBXDGMIME)
++	add_definitions(-DHAVE_LIBXDGMIME)
+ endif(LIBXDGMIME_FOUND)
+ 
+ file(GLOB OBJS src/*.cpp)

--- a/package/gmp/gmp.mk
+++ b/package/gmp/gmp.mk
@@ -15,7 +15,7 @@ HOST_GMP_DEPENDENCIES = host-m4
 
 # GMP doesn't support assembly for coldfire or mips r6 ISA yet
 # Disable for ARM v7m since it has different asm constraints
-ifeq ($(BR2_m68k_cf)$(BR2_MIPS_CPU_MIPS32R6)$(BR2_MIPS_CPU_MIPS64R6)$(BR2_ARM_CPU_ARMV7M),y)
+ifeq ($(BR2_m68k_cf)$(BR2_MIPS_CPU_MIPS32R6)$(BR2_MIPS_CPU_MIPS64R6)$(BR2_ARM_CPU_ARMV7M)$(BR2_mipsel),y)
 GMP_CONF_OPTS += --disable-assembly
 endif
 

--- a/package/libopk/0001-CMakeLists.txt.patch
+++ b/package/libopk/0001-CMakeLists.txt.patch
@@ -1,0 +1,12 @@
+diff -u libopk-6e90206/CMakeLists.txt libopk-6e90206/CMakeLists.txt
+--- libopk-6e90206/CMakeLists.txt	2019-10-03 00:59:36.629579083 +0200
++++ libopk-6e90206/CMakeLists.txt	2019-10-03 01:00:46.941602271 +0200
+@@ -21,7 +21,7 @@
+ 
+ pkg_check_modules(ZLIB QUIET zlib)
+ if (ZLIB_FOUND)
+-	add_compile_definitions(USE_GZIP)
++	add_definitions(-DUSE_GZIP)
+ 	link_directories(${ZLIB_LIBRARY_DIRS})
+ 	include_directories(${ZLIB_INCLUDE_DIRS})
+ endif (ZLIB_FOUND)


### PR DESCRIPTION
3 patches for gmenu2x, libopk, and gmp